### PR TITLE
Money.toNumericString should not do any formatting

### DIFF
--- a/src/main/java/com/domainlanguage/money/Money.java
+++ b/src/main/java/com/domainlanguage/money/Money.java
@@ -297,7 +297,7 @@ public class Money implements Comparable<Money>, Serializable {
   }
 
   public String toNumericString() {
-    return NumberUtils.format(amount.doubleValue(), currency.getDefaultFractionDigits());
+    return amount.toString();
   }
 
   public String toString(Locale locale) {

--- a/src/test/java/com/domainlanguage/money/MoneyTest.java
+++ b/src/test/java/com/domainlanguage/money/MoneyTest.java
@@ -185,11 +185,11 @@ public class MoneyTest extends TestCase {
     Assert.assertEquals("50", y50.toNumericString());
 
     Assert.assertEquals("$150,000,000.00", d15.times(10_000_000).toString());
-    Assert.assertEquals("150,000,000.00", d15.times(10_000_000).toNumericString());
+    Assert.assertEquals("150000000.00", d15.times(10_000_000).toNumericString());
     Assert.assertEquals("$150,000,000.00", d15.times(10_000_000).toString(Locale.US));
     Assert.assertEquals("USD 150,000,000.00", d15.times(10_000_000).toString(Locale.UK));
     Assert.assertEquals("¥500,000,000", y50.times(10_000_000).toString());
-    Assert.assertEquals("500,000,000", y50.times(10_000_000).toNumericString());
+    Assert.assertEquals("500000000", y50.times(10_000_000).toNumericString());
   }
 
   public void testFormatMoneyNicely() {


### PR DESCRIPTION
Both toString and toNumericString were adding commas.
